### PR TITLE
Changed message_floodguard logic and introduced global_message_floodguard

### DIFF
--- a/bin/config_sample/config.ini
+++ b/bin/config_sample/config.ini
@@ -46,8 +46,11 @@ multiclient_limit=15
 ; The maximum number of characters that an IC/OOC message can contain.
 maximum_characters=256
 
-; The minimum time between IC messages, in miliseconds. The default value is fine for most cases.
+; The minimum time between game messages in areas, in miliseconds. The default value is fine for most cases.
 message_floodguard=250
+
+; The minimum time between game messages in the server, in miliseconds. Unlike message_floodguard, this timer is shared globally in the server.
+global_message_floodguard=0
 
 ; The amount of seconds without interaction till a client is marked as AFK.
 afk_timeout = 300

--- a/core/include/area_data.h
+++ b/core/include/area_data.h
@@ -870,6 +870,20 @@ class AreaData : public QObject
      */
     QVector<int> joinedIDs() const;
 
+    /**
+     * @brief Returns whatever a game message may be broadcasted or not.
+     *
+     * @return True if expired; false otherwise.
+     */
+    bool isMessageAllowed() const;
+
+    /**
+     * @brief Starts a timer that determines whatever a game message may be broadcasted or not.
+     *
+     * @param f_duration The duration of the message floodguard timer.
+     */
+    void startMessageFloodguard(int f_duration);
+
   public slots:
 
     /**
@@ -1136,6 +1150,22 @@ class AreaData : public QObject
      * @brief Wether or not the jukebox is enabled in this area.
      */
     bool m_jukebox;
+
+    /**
+     * @brief Timer until the next IC message can be sent.
+     */
+    QTimer *m_message_floodguard_timer;
+
+    /**
+     * @brief If false, IC messages will be rejected.
+     */
+    bool m_can_send_ic_messages = true;
+
+  private slots:
+    /**
+     * @brief Allow game messages to be broadcasted.
+     */
+    void allowMessage();
 };
 
 #endif // AREA_DATA_H

--- a/core/include/config_manager.h
+++ b/core/include/config_manager.h
@@ -228,6 +228,13 @@ class ConfigManager
     static int messageFloodguard();
 
     /**
+     * @brief Returns the duration of the global message floodguard.
+     *
+     * @return See short description.
+     */
+    static int globalMessageFloodguard();
+
+    /**
      * @brief Returns the URL where the server should retrieve remote assets from.
      *
      * @return See short description.

--- a/core/include/server.h
+++ b/core/include/server.h
@@ -297,7 +297,7 @@ class Server : public QObject
      *
      * @return True if expired; false otherwise.
      */
-    bool isMessageAllowed();
+    bool isMessageAllowed() const;
 
     /**
      * @brief Starts a global timer that determines whatever a game message may be broadcasted or not.

--- a/core/src/area_data.cpp
+++ b/core/src/area_data.cpp
@@ -69,6 +69,8 @@ AreaData::AreaData(QString p_name, int p_index, MusicManager *p_music_manager = 
     m_jukebox_timer = new QTimer();
     connect(m_jukebox_timer, &QTimer::timeout,
             this, &AreaData::switchJukeboxSong);
+    m_message_floodguard_timer = new QTimer(this);
+    connect(m_message_floodguard_timer, &QTimer::timeout, this, &AreaData::allowMessage);
 }
 
 const QMap<QString, AreaData::Status> AreaData::map_statuses = {
@@ -288,6 +290,17 @@ QList<int> AreaData::invited() const
 bool AreaData::isMusicAllowed() const
 {
     return m_toggleMusic;
+}
+
+bool AreaData::isMessageAllowed() const
+{
+    return m_can_send_ic_messages;
+}
+
+void AreaData::startMessageFloodguard(int f_duration)
+{
+    m_can_send_ic_messages = false;
+    m_message_floodguard_timer->start(f_duration);
 }
 
 void AreaData::toggleMusic()
@@ -624,4 +637,9 @@ void AreaData::switchJukeboxSong()
     }
     setCurrentMusic(l_song_name);
     setMusicPlayedBy("Jukebox");
+}
+
+void AreaData::allowMessage()
+{
+    m_can_send_ic_messages = true;
 }

--- a/core/src/config_manager.cpp
+++ b/core/src/config_manager.cpp
@@ -383,6 +383,17 @@ int ConfigManager::messageFloodguard()
     return l_flood;
 }
 
+int ConfigManager::globalMessageFloodguard()
+{
+    bool ok;
+    int l_flood = m_settings->value("Options/global_message_floodguard", 0).toInt(&ok);
+    if (!ok) {
+        qWarning("global_message_floodguard is not an int!");
+        l_flood = 0;
+    }
+    return l_flood;
+}
+
 QUrl ConfigManager::assetUrl()
 {
     QByteArray l_url = m_settings->value("Options/asset_url", "").toString().toUtf8();

--- a/core/src/packets.cpp
+++ b/core/src/packets.cpp
@@ -210,7 +210,7 @@ void AOClient::pktIcChat(AreaData *area, int argc, QStringList argv, AOPacket pa
         return;
     }
 
-    if (!server->isMessageAllowed()) {
+    if (!!area->isMessageAllowed() || !server->isMessageAllowed()) {
         return;
     }
 
@@ -225,7 +225,8 @@ void AOClient::pktIcChat(AreaData *area, int argc, QStringList argv, AOPacket pa
     emit logIC((m_current_char + " " + m_showname), m_ooc_name, m_ipid, server->getAreaById(m_current_area)->name(), m_last_message);
     area->updateLastICMessage(validated_packet.contents);
 
-    server->startMessageFloodguard(ConfigManager::messageFloodguard());
+    area->startMessageFloodguard(ConfigManager::messageFloodguard());
+    server->startMessageFloodguard(ConfigManager::globalMessageFloodguard());
 }
 
 void AOClient::pktOocChat(AreaData *area, int argc, QStringList argv, AOPacket packet)

--- a/core/src/packets.cpp
+++ b/core/src/packets.cpp
@@ -210,7 +210,7 @@ void AOClient::pktIcChat(AreaData *area, int argc, QStringList argv, AOPacket pa
         return;
     }
 
-    if (!!area->isMessageAllowed() || !server->isMessageAllowed()) {
+    if (!area->isMessageAllowed() || !server->isMessageAllowed()) {
         return;
     }
 

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -252,7 +252,7 @@ QStringList Server::getCursedCharsTaken(AOClient *client, QStringList chars_take
     return chars_taken_cursed;
 }
 
-bool Server::isMessageAllowed()
+bool Server::isMessageAllowed() const
 {
     return m_can_send_ic_messages;
 }


### PR DESCRIPTION
Resolve #3

The client individual client timer was ignored in favor of the area timer as it wouldn't make a lot of sense to have 3 different timers for game messages.

* Changed message_floodguard to only affect the area in which the message was sent rather than globally. The default value is 250ms.
* Added global_message_floodguard, this restores the previous functionality of message_floodguard. The default value is 0ms.