### PR TITLE
Added a kickother command

### DIFF
--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -1375,6 +1375,15 @@ class AOClient : public QObject
      */
     void cmdClearCM(int argc, QStringList argv);
 
+    /**
+     * @brief Removes all other clients of the user except for the user.
+     *
+     * @details This command can be used to disconnect ghosting clients that improperly disconnected from the server.
+     *
+     * @iscommand
+     */
+    void cmdKickother(int argc, QStringList argv);
+
     ///@}
 
     /**

--- a/core/src/aoclient.cpp
+++ b/core/src/aoclient.cpp
@@ -145,7 +145,8 @@ const QMap<QString, AOClient::CommandInfo> AOClient::COMMANDS{
     {"toggleroot", {{ACLRole::CM}, 0, &AOClient::cmdToggleRootlist}},
     {"clearcustom", {{ACLRole::CM}, 0, &AOClient::cmdClearCustom}},
     {"togglewtce", {{ACLRole::CM}, 0, &AOClient::cmdToggleWtce}},
-    {"toggleshouts", {{ACLRole::CM}, 0, &AOClient::cmdToggleShouts}}};
+    {"toggleshouts", {{ACLRole::CM}, 0, &AOClient::cmdToggleShouts}},
+    {"kickother", {{ACLRole::NONE}, 0, &AOClient::cmdKickother}}};
 
 void AOClient::clientData()
 {

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -630,3 +630,25 @@ void AOClient::cmdClearCM(int argc, QStringList argv)
     arup(ARUPType::CM, true);
     sendServerMessage("Removed all CMs from this area.");
 }
+
+void AOClient::cmdKickother(int argc, QStringList argv)
+{
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
+    QList<AOClient *> l_invoker_clients = server->getClientsByIpid(m_ipid);
+
+    int l_clients_kicked = 0;
+
+    for ( AOClient* l_client : l_invoker_clients ) {
+
+        if(l_client->m_id != m_id){
+            l_client->m_socket->close();
+            l_clients_kicked++;
+        }
+
+    }
+
+    sendServerMessage("You removed " + QString::number(l_clients_kicked) + " of your clients.");
+
+}


### PR DESCRIPTION
Added a /kickother command that removes multi-clients of the invoker except for the one user of the command.
Can be used by every user, and is mostly intended to allow a user to kick his own ghost-clients.